### PR TITLE
[enhancement][Service] remove Context variable from Services (using Context from Constructor is ENOUGH) [UPDATE later: Services use RepositoryManager instead of Context]

### DIFF
--- a/LapStopApiSolution/Logic/Services/ServiceManager.cs
+++ b/LapStopApiSolution/Logic/Services/ServiceManager.cs
@@ -15,8 +15,6 @@ namespace Services
 {
     public sealed class ServiceManager : IServiceManager
     {
-        private readonly LapStopContext _context;
-
         private readonly Lazy<IBrandService> _brandService;
         private readonly Lazy<ICartService> _cartService;
         private readonly Lazy<ICartItemService> _cartItemService;
@@ -42,8 +40,6 @@ namespace Services
 
         public ServiceManager(LapStopContext context)
         {
-            _context = context;
-
             _brandService = new Lazy<IBrandService>(() => new BrandService(context));
             _cartService = new Lazy<ICartService>(() => new CartService(context));
             _cartItemService = new Lazy<ICartItemService>(() => new CartItemService(context));


### PR DESCRIPTION
- Repositories MUST have Context, because of using for SAVE method
- Services DON"T have SAVE => So don't need Context.