### PR TITLE
[feature][REST_API] seperate Controllers from Host

### DIFF
--- a/LapStopApiSolution/Infrastructures/LapStopRestApi/AssemblyReference.cs
+++ b/LapStopApiSolution/Infrastructures/LapStopRestApi/AssemblyReference.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LapStopRestApi
+{
+    public static class AssemblyReference
+    {
+    }
+}

--- a/LapStopApiSolution/Infrastructures/LapStopRestApi/Controllers/WeatherForecastController.cs
+++ b/LapStopApiSolution/Infrastructures/LapStopRestApi/Controllers/WeatherForecastController.cs
@@ -3,7 +3,7 @@ using Contracts.IServices;
 using DTO.Output;
 using Microsoft.AspNetCore.Mvc;
 
-namespace LapStopApiHost.Controllers
+namespace LapStopRestApi.Controllers
 {
     [ApiController]
     [Route("[controller]")]

--- a/LapStopApiSolution/Infrastructures/LapStopRestApi/LapStopRestApi.csproj
+++ b/LapStopApiSolution/Infrastructures/LapStopRestApi/LapStopRestApi.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Cores\Contracts\Contracts.csproj" />
+    <ProjectReference Include="..\..\DTO\DTO.csproj" />
+    <ProjectReference Include="..\..\Logic\Services\Services.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LapStopApiSolution/LapStopApiSolution.sln
+++ b/LapStopApiSolution/LapStopApiSolution.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DTO", "DTO\DTO.csproj", "{B
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LapStopApiHost", "MainHosts\LapStopApiHost\LapStopApiHost.csproj", "{087A5483-BBD1-401F-9D37-C3A97E78D1A7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LapStopRestApi", "Infrastructures\LapStopRestApi\LapStopRestApi.csproj", "{659920DC-02E8-4628-981D-5D5FCD81BCB6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{087A5483-BBD1-401F-9D37-C3A97E78D1A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{087A5483-BBD1-401F-9D37-C3A97E78D1A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{087A5483-BBD1-401F-9D37-C3A97E78D1A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{659920DC-02E8-4628-981D-5D5FCD81BCB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{659920DC-02E8-4628-981D-5D5FCD81BCB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{659920DC-02E8-4628-981D-5D5FCD81BCB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{659920DC-02E8-4628-981D-5D5FCD81BCB6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -78,6 +84,7 @@ Global
 		{E066D7BF-7529-45A1-A817-DDDC12603230} = {DC92C32D-9807-4B3E-9A37-BCF4F429ACC1}
 		{B97ADA03-5A64-44DF-A06C-9E7A687B92EE} = {D3491721-9A6F-48F8-B95E-5D7604B5AAD5}
 		{087A5483-BBD1-401F-9D37-C3A97E78D1A7} = {F1A23BD4-B06A-4649-A4CE-07C6FDF30ABA}
+		{659920DC-02E8-4628-981D-5D5FCD81BCB6} = {59F35292-BB7B-4C77-94D5-6CC3F3E47D89}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {14A8E5F8-492F-4B22-8DC7-0BFF3E7666F9}

--- a/LapStopApiSolution/MainHosts/LapStopApiHost/LapStopApiHost.csproj
+++ b/LapStopApiSolution/MainHosts/LapStopApiHost/LapStopApiHost.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\DTO\DTO.csproj" />
     <ProjectReference Include="..\..\Infrastructures\Entities\Entities.csproj" />
+    <ProjectReference Include="..\..\Infrastructures\LapStopRestApi\LapStopRestApi.csproj" />
     <ProjectReference Include="..\..\Infrastructures\NLogLib\NLogLib.csproj" />
     <ProjectReference Include="..\..\Logic\Services\Services.csproj" />
   </ItemGroup>

--- a/LapStopApiSolution/MainHosts/LapStopApiHost/Program.cs
+++ b/LapStopApiSolution/MainHosts/LapStopApiHost/Program.cs
@@ -16,7 +16,8 @@ LogManager.LoadConfiguration(
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddApplicationPart(typeof(LapStopRestApi.AssemblyReference).Assembly);
 builder.Services.AddDbContext<LapStopContext>(
     options => options.UseSqlServer(builder.Configuration.GetConnectionString("LapStopConnection"))
 );


### PR DESCRIPTION
**- Why do we need to seperate Controllers from Host ?**
   1) Due to DI of .NetCore, many projects will reference to Main 
    => Controllers can use ANYTHING in these projects (Nothing can restrict Controllers)
    => New Controller module is ONLY interacting with Services (CAN"T call to Repositories, Context) 
    2) There are many type of API: REST, GraphQL, gRPC...
    => Dividing Controllers to a different module is better for extending Code 