### PR TITLE
[enhancement][Optimized] Remove AutoMapper's syntax code from ServiceCode

### DIFF
--- a/LapStopApiSolution/Cores/Contracts.IServices/IServiceBase.cs
+++ b/LapStopApiSolution/Cores/Contracts.IServices/IServiceBase.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Contracts.IServices
+{
+    public interface IServiceBase
+    {
+        TDestination MappingTo<TDestination>(object source);
+    }
+}

--- a/LapStopApiSolution/Logic/Services/Models/BrandService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/BrandService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<BrandDto> GetAll(bool isTrackChanges)
         {
             List<Brand> brands = _repositoryManager.Brand.GetAll(isTrackChanges);
-            return _mapper.Map<List<BrandDto>>(brands);
+            return MappingTo<List<BrandDto>>(brands);
         }
 
         public BrandDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(Brand), nameof(GetById), id);
             }
-            return _mapper.Map<BrandDto>(brand);
+            return MappingTo<BrandDto>(brand);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/CartItemService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/CartItemService.cs
@@ -20,7 +20,7 @@ namespace Services.Models
                 throw new NotFoundException404(typeof(Cart), nameof(GetByCartId), cartId);
             }
             List<CartItem> cartItems = _repositoryManager.CartItem.GetByCartId(isTrackChanges: false, cartId);
-            return _mapper.Map<List<CartItemDto>>(cartItems);
+            return MappingTo<List<CartItemDto>>(cartItems);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/CartService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/CartService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<CartDto> GetAll(bool isTrackChanges)
         {
             List<Cart> carts = _repositoryManager.Cart.GetAll(isTrackChanges);
-            return _mapper.Map<List<CartDto>>(carts);
+            return MappingTo<List<CartDto>>(carts);
         }
 
         public CartDto? GetByCustomerId(bool isTrackChanges, Guid customerId)
@@ -30,7 +30,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(Cart), nameof(GetByCustomerId), customerId);
             }
-            return _mapper.Map<CartDto>(cart);
+            return MappingTo<CartDto>(cart);
         }
 
         public bool IsValidCartId(Guid cartId)

--- a/LapStopApiSolution/Logic/Services/Models/CustomerAccountService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/CustomerAccountService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<CustomerAccountDto> GetAll(bool isTrackChanges)
         {
             List<CustomerAccount> customerAccounts = _repositoryManager.CustomerAccount.GetAll(isTrackChanges);
-            return _mapper.Map<List<CustomerAccountDto>>(customerAccounts);
+            return MappingTo<List<CustomerAccountDto>>(customerAccounts);
         }
 
         public CustomerAccountDto? GetByCustomerId(bool isTrackChanges, Guid customerId)
@@ -30,7 +30,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(CustomerAccount), nameof(GetByCustomerId), customerId);
             }
-            return _mapper.Map<CustomerAccountDto>(customerAccount);
+            return MappingTo<CustomerAccountDto>(customerAccount);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/CustomerService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/CustomerService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<CustomerDto> GetAll(bool isTrackChanges)
         {
             List<Customer> customers = _repositoryManager.Customer.GetAll(isTrackChanges);
-            return _mapper.Map<List<CustomerDto>>(customers);
+            return MappingTo<List<CustomerDto>>(customers);
         }
 
         public CustomerDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(Customer), nameof(GetById), id);
             }
-            return _mapper.Map<CustomerDto>(customer);
+            return MappingTo<CustomerDto>(customer);
         }
 
         public bool IsValidCustomerId(Guid customerId)

--- a/LapStopApiSolution/Logic/Services/Models/EmployeeRoleService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/EmployeeRoleService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<EmployeeRoleDto> GetAll(bool isTrackChanges)
         {
             List<EmployeeRole> employeeRoles = _repositoryManager.EmployeeRole.GetAll(isTrackChanges);
-            return _mapper.Map<List<EmployeeRoleDto>>(employeeRoles);
+            return MappingTo<List<EmployeeRoleDto>>(employeeRoles);
         }
 
         public EmployeeRoleDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(EmployeeRole), nameof(GetById), id);
             }
-            return _mapper?.Map<EmployeeRoleDto>(employeeRole);
+            return MappingTo<EmployeeRoleDto>(employeeRole);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/EmployeeStatusService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/EmployeeStatusService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<EmployeeStatusDto> GetAll(bool isTrackChanges)
         {
             List<EmployeeStatus> employeeStatuses = _repositoryManager.EmployeeStatus.GetAll(isTrackChanges);
-            return _mapper.Map<List<EmployeeStatusDto>>(employeeStatuses);
+            return MappingTo<List<EmployeeStatusDto>>(employeeStatuses);
         }
 
         public EmployeeStatusDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(EmployeeStatus), nameof(GetById), id);
             }
-            return _mapper.Map<EmployeeStatusDto>(employeeStatus); 
+            return MappingTo<EmployeeStatusDto>(employeeStatus); 
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/InvoiceStatusService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/InvoiceStatusService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<InvoiceStatusDto> GetAll(bool isTrackChanges)
         {
             List<InvoiceStatus> invoiceStatuses = _repositoryManager.InvoiceStatus.GetAll(isTrackChanges);
-            return _mapper.Map<List<InvoiceStatusDto>>(invoiceStatuses);
+            return MappingTo<List<InvoiceStatusDto>>(invoiceStatuses);
         }
 
         public InvoiceStatusDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(InvoiceStatus), nameof(GetById), id);
             }
-            return _mapper.Map<InvoiceStatusDto>(invoiceStatus);
+            return MappingTo<InvoiceStatusDto>(invoiceStatus);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/ProductStatusService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/ProductStatusService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<ProductStatusDto> GetAll(bool isTrackChanges)
         {
             List<ProductStatus> productStatuses = _repositoryManager.ProductStatus.GetAll(isTrackChanges);
-            return _mapper.Map<List<ProductStatusDto>>(productStatuses);
+            return MappingTo<List<ProductStatusDto>>(productStatuses);
         }
 
         public ProductStatusDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(ProductStatus), nameof(GetById), id);
             }
-            return _mapper.Map<ProductStatusDto>(productStatus);
+            return MappingTo<ProductStatusDto>(productStatus);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/Models/SalesOrderStatusService.cs
+++ b/LapStopApiSolution/Logic/Services/Models/SalesOrderStatusService.cs
@@ -16,7 +16,7 @@ namespace Services.Models
         public List<SalesOrderStatusDto> GetAll(bool isTrackChanges)
         {
             List<SalesOrderStatus> salesOrderStatuses = _repositoryManager.SalesOrderStatus.GetAll(isTrackChanges);
-            return _mapper.Map<List<SalesOrderStatusDto>>(salesOrderStatuses);
+            return MappingTo<List<SalesOrderStatusDto>>(salesOrderStatuses);
         }
 
         public SalesOrderStatusDto? GetById(bool isTrackChanges, Guid id)
@@ -26,7 +26,7 @@ namespace Services.Models
             {
                 throw new NotFoundException404(typeof(SalesOrderStatus), nameof(GetById), id);
             }
-            return _mapper.Map<SalesOrderStatusDto>(salesOrderStatus);
+            return MappingTo<SalesOrderStatusDto>(salesOrderStatus);
         }
     }
 }

--- a/LapStopApiSolution/Logic/Services/ServiceBase.cs
+++ b/LapStopApiSolution/Logic/Services/ServiceBase.cs
@@ -1,17 +1,24 @@
 ﻿using AutoMapper;
 using Contracts.IRepositories;
+using Contracts.IServices;
 
 namespace Services
 {
-    internal abstract class ServiceBase
+    internal abstract class ServiceBase : IServiceBase
     {
-        protected IRepositoryManager _repositoryManager; 
-        protected IMapper _mapper;
+        protected readonly IRepositoryManager _repositoryManager; 
+        private readonly IMapper _mapper;
 
         internal ServiceBase(IRepositoryManager repositoryManager, IMapper mapper)
         {
             _repositoryManager = repositoryManager;
             _mapper = mapper;
         }
+
+        public TDestination MappingTo<TDestination>(object source)
+        {
+            return _mapper.Map<TDestination>(source);
+        }
+
     }
 }


### PR DESCRIPTION
- Remove AutoMapper's syntax from ServiceCode. It's easy for extensing code, if you want to change another Lib ==> Just replace syntax code in ONE place.