### PR TITLE
[Enhancement][Config] Disable handling 400 Error of [ApiController] anotation

### DIFF
--- a/LapStopApiSolution/MainHosts/LapStopApiHost/Program.cs
+++ b/LapStopApiSolution/MainHosts/LapStopApiHost/Program.cs
@@ -1,8 +1,10 @@
+using Azure;
 using Contracts.ILog;
 using Contracts.IRepositories;
 using Contracts.IServices;
 using Entities.Context;
 using LapStopApiHost.Extensions;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using NLog;
 using NLogLib;
@@ -15,6 +17,13 @@ LogManager.LoadConfiguration(
 );
 
 var builder = WebApplication.CreateBuilder(args);
+
+// right ABOVE the AddControllers() method
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.SuppressModelStateInvalidFilter = true;  // disable 400 – Bad Request responses.
+});
+
 
 // Add services to the container.
 builder.Services.AddAutoMapper(typeof(AutoMapperLib.MappingProfile));


### PR DESCRIPTION
- Some functionalities of [ApiController] attribute:
  1) Automatic HTTP 400 responses
     ==> It handles the HTTP 400 responses with INvalid params (when using Anotation on DtoClass: [Required],...)
     ==> **It prevents us from sending our custom responses with different messages and status codes to the client.**
     ==> Using the blow commands to DISABLE this feature.
  2) Bind source parameter inference
  3) Multipart/form-data request inference
  4) Problem details for error status codes
- Besides, we can commented [ApiController], but we need some OTHER functionalities of [ApiController], not just handle 400 responses.