### PR TITLE
[Feature][Order] create BaseModel and Config the Order Columns

### DIFF
--- a/LapStopApiSolution/Cores/Domains/Base/BaseModel.cs
+++ b/LapStopApiSolution/Cores/Domains/Base/BaseModel.cs
@@ -1,0 +1,12 @@
+﻿
+namespace Domains.Base
+{
+    public abstract class BaseModel
+    {
+        public bool IsRemoved { get; set; }
+
+        public DateTime CreatedDate { get; set; }
+
+        public DateTime UpdatedDate { get; set; }
+    }
+}

--- a/LapStopApiSolution/Cores/Domains/Models/Brand.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/Brand.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class Brand
+    public sealed class Brand : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Description { get; set; }
 
         public string? AvatarUrl { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/Cart.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/Cart.cs
@@ -1,24 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class Cart
+    public sealed class Cart : BaseModel
     {
         public Guid Id { get; set; }
 
         public Guid CustomerId { get; set; }
 
         public int Total { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/CartItem.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/CartItem.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class CartItem
+    public sealed class CartItem : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -19,12 +15,6 @@ namespace Domains.Models
         public int SellingPrice { get; set; }
 
         public int SubTotal { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/Customer.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/Customer.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class Customer
+    public sealed class Customer : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -17,12 +13,6 @@ namespace Domains.Models
         public string? Address { get; set; }
 
         public string? Phone { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/CustomerAccount.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/CustomerAccount.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class CustomerAccount
+    public sealed class CustomerAccount : BaseModel
     {
         public Guid CustomerId { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Password { get; set; }
 
         public bool IsActivate { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/Employee.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/Employee.cs
@@ -1,13 +1,8 @@
-﻿using Domains.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class Employee
+    public sealed class Employee : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -32,12 +27,6 @@ namespace Domains.Models
         public string? Phone { get; set; }
 
         public string? AvatarUrl { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/EmployeeAccount.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/EmployeeAccount.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class EmployeeAccount
+    public sealed class EmployeeAccount : BaseModel
     {
         public Guid EmployeeId { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Password { get; set; }
 
         public bool IsActivate { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/EmployeeGallery.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/EmployeeGallery.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class EmployeeGallery
+    public sealed class EmployeeGallery : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Title { get; set; }
 
         public string? Url { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
 
         #region NAVIGATION PROPERTIES

--- a/LapStopApiSolution/Cores/Domains/Models/EmployeeRole.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/EmployeeRole.cs
@@ -1,25 +1,14 @@
-﻿using Domains.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class EmployeeRole
+    public sealed class EmployeeRole : BaseModel
     {
         public Guid Id { get; set; }
 
         public string? Name { get; set; }
 
         public bool IsEnable { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/EmployeeStatus.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/EmployeeStatus.cs
@@ -1,24 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class EmployeeStatus
+    public sealed class EmployeeStatus : BaseModel
     {
         public Guid Id { get; set; }
 
         public string? Name { get; set; }
 
         public bool IsEnable { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ExportedInvoice.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ExportedInvoice.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ExportedInvoice
+    public sealed class ExportedInvoice : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -21,12 +17,6 @@ namespace Domains.Models
         public DateTime InvoiceDate { get; set; }
 
         public int Total { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ExportedInvoiceDetail.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ExportedInvoiceDetail.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ExportedInvoiceDetail
+    public sealed class ExportedInvoiceDetail : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -21,12 +17,6 @@ namespace Domains.Models
         public int Quantity { get; set; }
 
         public int SubTotal { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ImportedInvoice.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ImportedInvoice.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ImportedInvoice
+    public sealed class ImportedInvoice : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -19,12 +15,6 @@ namespace Domains.Models
         public DateTime? InvoiceDate { get; set; }
 
         public int Total { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ImportedInvoiceDetail.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ImportedInvoiceDetail.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ImportedInvoiceDetail
+    public sealed class ImportedInvoiceDetail : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -21,12 +17,6 @@ namespace Domains.Models
         public int Quantity { get; set; }
 
         public int SubTotal { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/InvoiceStatus.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/InvoiceStatus.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class InvoiceStatus
+    public sealed class InvoiceStatus : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Description { get; set; }
 
         public bool IsEnable { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/Product.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/Product.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class Product
+    public sealed class Product : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -27,12 +23,6 @@ namespace Domains.Models
         public int SellingPrice { get; set; }
 
         public bool IsHiddenInStore { get; set; }
-
-        public bool IsRemoved { get; set;  }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ProductBrand.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ProductBrand.cs
@@ -1,22 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ProductBrand
+    public sealed class ProductBrand : BaseModel
     {
         public Guid ProductId { get; set; }
 
         public Guid BrandId { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ProductGallery.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ProductGallery.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ProductGallery
+    public sealed class ProductGallery : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Title { get; set; }
 
         public string? Url { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/ProductStatus.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/ProductStatus.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class ProductStatus
+    public sealed class ProductStatus : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Description { get; set; }
 
         public bool IsEnable { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/SalesOrder.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/SalesOrder.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class SalesOrder
+    public sealed class SalesOrder : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -21,12 +17,6 @@ namespace Domains.Models
         public string? Phone { get; set; }
 
         public int Total { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Cores/Domains/Models/SalesOrderDetail.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/SalesOrderDetail.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class SalesOrderDetail
+    public sealed class SalesOrderDetail : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -19,12 +15,6 @@ namespace Domains.Models
         public int SellingPrice { get; set; }
 
         public int SubTotal { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
 
         #region NAVIGATION PROPERTIES

--- a/LapStopApiSolution/Cores/Domains/Models/SalesOrderStatus.cs
+++ b/LapStopApiSolution/Cores/Domains/Models/SalesOrderStatus.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Domains.Base;
 
 namespace Domains.Models
 {
-    public sealed class SalesOrderStatus
+    public sealed class SalesOrderStatus : BaseModel
     {
         public Guid Id { get; set; }
 
@@ -15,12 +11,6 @@ namespace Domains.Models
         public string? Description { get; set; }
 
         public bool IsEnable { get; set; }
-
-        public bool IsRemoved { get; set; }
-
-        public DateTime CreatedDate { get; set; }
-
-        public DateTime UpdatedDate { get; set; }
 
         #region NAVIGATION PROPERTIES
 

--- a/LapStopApiSolution/Infrastructures/Entities/Context/LapStopContext.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Context/LapStopContext.cs
@@ -1,4 +1,5 @@
-﻿using Domains.Models;
+﻿using Domains.Base;
+using Domains.Models;
 using Entities.Configurations;
 using Entities.Extensions;
 using Microsoft.EntityFrameworkCore;
@@ -19,6 +20,8 @@ namespace Entities.Context
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.ApplyOrderConfigExt();
+
             modelBuilder.ApplyAttributeConfigExt();
 
             modelBuilder.ApplyRelationshipConfigExt();

--- a/LapStopApiSolution/Infrastructures/Entities/Extensions/ModelBuilderExt.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Extensions/ModelBuilderExt.cs
@@ -6,11 +6,855 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Domains.Base;
 
 namespace Entities.Extensions
 {
     public static class ModelBuilderExt
     {
+        public static void ApplyOrderConfigExt(this ModelBuilder modelBuilder)
+        {
+
+            // When you config BaseModel
+            // => This means that include Mapping it
+            // => But we don't want to map it
+            // => MUST config for EACH model
+            #region BASE MODEL (ERROR)
+
+            //modelBuilder.Entity<BaseModel>()
+            //    .Property(b => b.CreatedDate)
+            //    .HasColumnOrder(27);
+
+            //modelBuilder.Entity<BaseModel>()
+            //    .Property(b => b.UpdatedDate)
+            //    .HasColumnOrder(28);
+
+            //modelBuilder.Entity<BaseModel>()
+            //    .Property(b => b.IsRemoved)
+            //    .HasColumnOrder(29);
+
+            #endregion
+
+            // CONFIG the ORDER for the all Models
+
+            #region Brand
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.Name)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.Description)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.AvatarUrl)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<Brand>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region Cart
+
+            modelBuilder.Entity<Cart>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<Cart>()
+                .Property(b => b.CustomerId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<Cart>()
+                .Property(b => b.Total)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<Cart>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<Cart>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<Cart>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region CartItem
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.CartId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.ProductId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.Quantity)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.SellingPrice)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.SubTotal)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<CartItem>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region Customer
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.FirstName)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.LastName)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.Address)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.Phone)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<Customer>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region CustomerAccount
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.CustomerId)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.Username)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.Password)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.IsActivate)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<CustomerAccount>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region Employee
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.EmployeeRoleId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.EmployeeStatusId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.EmployeeCode)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.FirstName)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.LastName)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.IsMale)
+                .HasColumnOrder(7);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.DOB)
+                .HasColumnOrder(8);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.Address)
+                .HasColumnOrder(9);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.Email)
+                .HasColumnOrder(10);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.Phone)
+                .HasColumnOrder(11);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.AvatarUrl)
+                .HasColumnOrder(12);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<Employee>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region EmployeeAccount
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.EmployeeId)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.Username)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.Password)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.IsActivate)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<EmployeeAccount>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region EmployeeGallery
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.EmployeeId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.Title)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.Url)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<EmployeeGallery>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region EmployeeRole
+
+            modelBuilder.Entity<EmployeeRole>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<EmployeeRole>()
+                .Property(b => b.Name)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<EmployeeRole>()
+                .Property(b => b.IsEnable)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<EmployeeRole>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<EmployeeRole>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<EmployeeRole>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region EmployeeStatus
+
+            modelBuilder.Entity<EmployeeStatus>()
+            .Property(b => b.Id)
+            .HasColumnOrder(1);
+
+            modelBuilder.Entity<EmployeeStatus>()
+                .Property(b => b.Name)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<EmployeeStatus>()
+                .Property(b => b.IsEnable)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<EmployeeStatus>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<EmployeeStatus>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<EmployeeStatus>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ExportedInvoice
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.SalesOrderId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.EmployeeId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.InvoiceStatusId)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.InvoiceCode)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.InvoiceDate)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.Total)
+                .HasColumnOrder(7);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ExportedInvoice>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ExportedInvoiceDetail
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.ExportedInvoiceId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.ProductId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.ProductBarcode)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.SellingPrice)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.Quantity)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.SubTotal)
+                .HasColumnOrder(7);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ExportedInvoiceDetail>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ImportedInvoice
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.EmployeeId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.InvoiceStatusId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.InvoiceCode)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.InvoiceDate)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.Total)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ImportedInvoice>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ImportedInvoiceDetail
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.ImportedInvoiceId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.ProductId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.ProductBarcode)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.CostPrice)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.Quantity)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.SubTotal)
+                .HasColumnOrder(7);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ImportedInvoiceDetail>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region InvoiceStatus
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.Name)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.Description)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.IsEnable)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<InvoiceStatus>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region Product
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.ProductStatusId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.ProductCode)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.Name)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.Description)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.AvatarUrl)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.OriginalPrice)
+                .HasColumnOrder(7);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.CurrentPrice)
+                .HasColumnOrder(8);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.SellingPrice)
+                .HasColumnOrder(9);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.IsHiddenInStore)
+                .HasColumnOrder(10);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<Product>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ProductBrand
+
+            modelBuilder.Entity<ProductBrand>()
+            .Property(b => b.ProductId)
+            .HasColumnOrder(1);
+
+            modelBuilder.Entity<ProductBrand>()
+                .Property(b => b.BrandId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ProductBrand>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ProductBrand>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ProductBrand>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ProductGallery
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.ProductId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.Title)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.Url)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ProductGallery>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region ProductStatus
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.Name)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.Description)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.IsEnable)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<ProductStatus>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region SalesOrder
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.CustomerId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.SalesOrderStatusId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.OrderDate)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.Address)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.Phone)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.Total)
+                .HasColumnOrder(7);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<SalesOrder>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region SalesOrderDetail
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.SalesOrderId)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.ProductId)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.Quantity)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.SellingPrice)
+                .HasColumnOrder(5);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.SubTotal)
+                .HasColumnOrder(6);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<SalesOrderDetail>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+            #region SalesOrderStatus
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.Id)
+                .HasColumnOrder(1);
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.Name)
+                .HasColumnOrder(2);
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.Description)
+                .HasColumnOrder(3);
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.IsEnable)
+                .HasColumnOrder(4);
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.CreatedDate)
+                .HasColumnOrder(27);
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.UpdatedDate)
+                .HasColumnOrder(28);
+
+            modelBuilder.Entity<SalesOrderStatus>()
+                .Property(b => b.IsRemoved)
+                .HasColumnOrder(29);
+
+            #endregion
+
+        }
+
         public static void ApplyAttributeConfigExt(this ModelBuilder modelBuilder)
         {
             #region CUSTOMER ACCOUNT
@@ -54,9 +898,8 @@ namespace Entities.Extensions
                 .IsRequired(true); // NOT nullable
 
             #endregion
-
         }
-                
+
         public static void ApplyRelationshipConfigExt(this ModelBuilder modelBuilder)
         {
             /// <summary>

--- a/LapStopApiSolution/Infrastructures/Entities/Migrations/20230425111806_InitialDB.Designer.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Migrations/20230425111806_InitialDB.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Entities.Migrations
 {
     [DbContext(typeof(LapStopContext))]
-    [Migration("20230416052449_InitialDB")]
+    [Migration("20230425111806_InitialDB")]
     partial class InitialDB
     {
         /// <inheritdoc />
@@ -29,25 +29,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("AvatarUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -58,22 +65,28 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("CustomerId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -87,31 +100,40 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<Guid>("CartId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(4);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -126,28 +148,36 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("Address")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("FirstName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("LastName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<string>("Phone")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -157,27 +187,34 @@ namespace Entities.Migrations
             modelBuilder.Entity("Domains.Models.CustomerAccount", b =>
                 {
                     b.Property<Guid>("CustomerId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsActivate")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Password")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)")
-                        .HasColumnName("Username");
+                        .HasColumnName("Username")
+                        .HasColumnOrder(2);
 
                     b.HasKey("CustomerId")
                         .HasName("CustomerId");
@@ -189,49 +226,64 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("Address")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(9);
 
                     b.Property<string>("AvatarUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(12);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<DateTime>("DOB")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(8);
 
                     b.Property<string>("Email")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(10);
 
                     b.Property<string>("EmployeeCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("EmployeeRoleId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<Guid>("EmployeeStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<string>("FirstName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<bool?>("IsMale")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(7);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("LastName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(6);
 
                     b.Property<string>("Phone")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(11);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -245,27 +297,34 @@ namespace Entities.Migrations
             modelBuilder.Entity("Domains.Models.EmployeeAccount", b =>
                 {
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsActivate")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Password")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)")
-                        .HasColumnName("Username");
+                        .HasColumnName("Username")
+                        .HasColumnOrder(2);
 
                     b.HasKey("EmployeeId")
                         .HasName("EmployeeId");
@@ -277,25 +336,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Url")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.HasKey("Id");
 
@@ -308,22 +374,28 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -334,22 +406,28 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -360,34 +438,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<string>("InvoiceCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("InvoiceDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(6);
 
                     b.Property<Guid>("InvoiceStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("SalesOrderId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -405,34 +493,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("ExportedInvoiceId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("ProductBarcode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -447,31 +545,40 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<string>("InvoiceCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<DateTime?>("InvoiceDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(5);
 
                     b.Property<Guid>("InvoiceStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -486,34 +593,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<int>("CostPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("ImportedInvoiceId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("ProductBarcode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -528,25 +645,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -557,43 +681,56 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("AvatarUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<int>("CurrentPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(8);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<bool>("IsHiddenInStore")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(10);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<int>("OriginalPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<string>("ProductCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<Guid>("ProductStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(9);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -606,20 +743,25 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("ProductId")
                         .HasColumnType("uniqueidentifier")
-                        .HasColumnName("ProductId");
+                        .HasColumnName("ProductId")
+                        .HasColumnOrder(1);
 
                     b.Property<Guid>("BrandId")
                         .HasColumnType("uniqueidentifier")
-                        .HasColumnName("BrandId");
+                        .HasColumnName("BrandId")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("ProductId", "BrandId");
 
@@ -632,25 +774,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Url")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.HasKey("Id");
 
@@ -663,25 +812,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -692,34 +848,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("Address")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("CustomerId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<DateTime>("OrderDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(4);
 
                     b.Property<string>("Phone")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(6);
 
                     b.Property<Guid>("SalesOrderStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -734,31 +900,40 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("SalesOrderId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -773,25 +948,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 

--- a/LapStopApiSolution/Infrastructures/Entities/Migrations/20230425111806_InitialDB.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Migrations/20230425111806_InitialDB.cs
@@ -19,9 +19,9 @@ namespace Entities.Migrations
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     AvatarUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -37,9 +37,9 @@ namespace Entities.Migrations
                     LastName = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -53,9 +53,9 @@ namespace Entities.Migrations
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsEnable = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -69,9 +69,9 @@ namespace Entities.Migrations
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsEnable = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -86,9 +86,9 @@ namespace Entities.Migrations
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsEnable = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -103,9 +103,9 @@ namespace Entities.Migrations
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsEnable = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -120,9 +120,9 @@ namespace Entities.Migrations
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsEnable = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -136,9 +136,9 @@ namespace Entities.Migrations
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     CustomerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Total = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -159,9 +159,9 @@ namespace Entities.Migrations
                     Username = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Password = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsActivate = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -190,9 +190,9 @@ namespace Entities.Migrations
                     Email = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     AvatarUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -225,9 +225,9 @@ namespace Entities.Migrations
                     CurrentPrice = table.Column<int>(type: "int", nullable: false),
                     SellingPrice = table.Column<int>(type: "int", nullable: false),
                     IsHiddenInStore = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -251,9 +251,9 @@ namespace Entities.Migrations
                     Address = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Phone = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Total = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -280,9 +280,9 @@ namespace Entities.Migrations
                     Username = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     Password = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     IsActivate = table.Column<bool>(type: "bit", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -303,9 +303,9 @@ namespace Entities.Migrations
                     EmployeeId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Url = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -328,9 +328,9 @@ namespace Entities.Migrations
                     InvoiceCode = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     InvoiceDate = table.Column<DateTime>(type: "datetime2", nullable: true),
                     Total = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -359,9 +359,9 @@ namespace Entities.Migrations
                     Quantity = table.Column<int>(type: "int", nullable: false),
                     SellingPrice = table.Column<int>(type: "int", nullable: false),
                     SubTotal = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -386,9 +386,9 @@ namespace Entities.Migrations
                 {
                     ProductId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     BrandId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -415,9 +415,9 @@ namespace Entities.Migrations
                     ProductId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Title = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     Url = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -441,9 +441,9 @@ namespace Entities.Migrations
                     InvoiceCode = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     InvoiceDate = table.Column<DateTime>(type: "datetime2", nullable: false),
                     Total = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -478,9 +478,9 @@ namespace Entities.Migrations
                     Quantity = table.Column<int>(type: "int", nullable: false),
                     SellingPrice = table.Column<int>(type: "int", nullable: false),
                     SubTotal = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -510,9 +510,9 @@ namespace Entities.Migrations
                     CostPrice = table.Column<int>(type: "int", nullable: false),
                     Quantity = table.Column<int>(type: "int", nullable: false),
                     SubTotal = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -542,9 +542,9 @@ namespace Entities.Migrations
                     SellingPrice = table.Column<int>(type: "int", nullable: false),
                     Quantity = table.Column<int>(type: "int", nullable: false),
                     SubTotal = table.Column<int>(type: "int", nullable: false),
-                    IsRemoved = table.Column<bool>(type: "bit", nullable: false),
                     CreatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    UpdatedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRemoved = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/LapStopApiSolution/Infrastructures/Entities/Migrations/LapStopContextModelSnapshot.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Migrations/LapStopContextModelSnapshot.cs
@@ -26,25 +26,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("AvatarUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -55,22 +62,28 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("CustomerId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -84,31 +97,40 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<Guid>("CartId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(4);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -123,28 +145,36 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("Address")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("FirstName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("LastName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<string>("Phone")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -154,27 +184,34 @@ namespace Entities.Migrations
             modelBuilder.Entity("Domains.Models.CustomerAccount", b =>
                 {
                     b.Property<Guid>("CustomerId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsActivate")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Password")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)")
-                        .HasColumnName("Username");
+                        .HasColumnName("Username")
+                        .HasColumnOrder(2);
 
                     b.HasKey("CustomerId")
                         .HasName("CustomerId");
@@ -186,49 +223,64 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("Address")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(9);
 
                     b.Property<string>("AvatarUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(12);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<DateTime>("DOB")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(8);
 
                     b.Property<string>("Email")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(10);
 
                     b.Property<string>("EmployeeCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("EmployeeRoleId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<Guid>("EmployeeStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<string>("FirstName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<bool?>("IsMale")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(7);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("LastName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(6);
 
                     b.Property<string>("Phone")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(11);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -242,27 +294,34 @@ namespace Entities.Migrations
             modelBuilder.Entity("Domains.Models.EmployeeAccount", b =>
                 {
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsActivate")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Password")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Username")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)")
-                        .HasColumnName("Username");
+                        .HasColumnName("Username")
+                        .HasColumnOrder(2);
 
                     b.HasKey("EmployeeId")
                         .HasName("EmployeeId");
@@ -274,25 +333,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Url")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.HasKey("Id");
 
@@ -305,22 +371,28 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -331,22 +403,28 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -357,34 +435,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<string>("InvoiceCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("InvoiceDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(6);
 
                     b.Property<Guid>("InvoiceStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("SalesOrderId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -402,34 +490,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("ExportedInvoiceId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("ProductBarcode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -444,31 +542,40 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("EmployeeId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<string>("InvoiceCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<DateTime?>("InvoiceDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(5);
 
                     b.Property<Guid>("InvoiceStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -483,34 +590,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<int>("CostPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("ImportedInvoiceId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("ProductBarcode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -525,25 +642,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -554,43 +678,56 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("AvatarUrl")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<int>("CurrentPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(8);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<bool>("IsHiddenInStore")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(10);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.Property<int>("OriginalPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<string>("ProductCode")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<Guid>("ProductStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(9);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -603,20 +740,25 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("ProductId")
                         .HasColumnType("uniqueidentifier")
-                        .HasColumnName("ProductId");
+                        .HasColumnName("ProductId")
+                        .HasColumnOrder(1);
 
                     b.Property<Guid>("BrandId")
                         .HasColumnType("uniqueidentifier")
-                        .HasColumnName("BrandId");
+                        .HasColumnName("BrandId")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("ProductId", "BrandId");
 
@@ -629,25 +771,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<string>("Title")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.Property<string>("Url")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(4);
 
                     b.HasKey("Id");
 
@@ -660,25 +809,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -689,34 +845,44 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<string>("Address")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(5);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<Guid>("CustomerId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<DateTime>("OrderDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(4);
 
                     b.Property<string>("Phone")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(6);
 
                     b.Property<Guid>("SalesOrderStatusId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Total")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(7);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -731,31 +897,40 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(3);
 
                     b.Property<int>("Quantity")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(4);
 
                     b.Property<Guid>("SalesOrderId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(2);
 
                     b.Property<int>("SellingPrice")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(5);
 
                     b.Property<int>("SubTotal")
-                        .HasColumnType("int");
+                        .HasColumnType("int")
+                        .HasColumnOrder(6);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 
@@ -770,25 +945,32 @@ namespace Entities.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uniqueidentifier")
+                        .HasColumnOrder(1);
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(27);
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(3);
 
                     b.Property<bool>("IsEnable")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(4);
 
                     b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                        .HasColumnType("bit")
+                        .HasColumnOrder(29);
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(max)")
+                        .HasColumnOrder(2);
 
                     b.Property<DateTime>("UpdatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime2")
+                        .HasColumnOrder(28);
 
                     b.HasKey("Id");
 


### PR DESCRIPTION
- Create BaseModel for all Models ==> easy for controlling
=> But when inheriting, these columns will be added to the TOP
=> Have to ORDER these columns
      + CAN NOT Config order for the BaseModel, although we added [NotMapped] attribue or modelBuilder.Ignore<>
          --> Always ERROR, because Context WILL ADD the BaseModel class when executing Migration commands
          --> Have to write Config for EACH MODELS.
- When write Config for EACH MODELS:
     + If just write for the needed Columns --> it's NOT effective.
     ==> MUST write  the Order config for ALL COLUMNS of EACH MODEL.