### PR TITLE
[Fixbug][SeedingData] Use the SPECIFIC value for SeedingData, NOT use Datetime.Now

### DIFF
--- a/LapStopApiSolution/Infrastructures/Entities/Configurations/EmployeeRoleConfig.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Configurations/EmployeeRoleConfig.cs
@@ -17,8 +17,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.EMPLOYEE_ROLE.Admin.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new EmployeeRole()
                 {
@@ -26,8 +26,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.EMPLOYEE_ROLE.Manager.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new EmployeeRole()
                 {
@@ -35,8 +35,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.EMPLOYEE_ROLE.Staff.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 }
             );
         }

--- a/LapStopApiSolution/Infrastructures/Entities/Configurations/EmployeeStatusConfig.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Configurations/EmployeeStatusConfig.cs
@@ -17,8 +17,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.EMPLOYEE_STATUS.On.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new EmployeeStatus()
                 {
@@ -26,8 +26,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.EMPLOYEE_STATUS.Off.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new EmployeeStatus()
                 {
@@ -35,8 +35,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.EMPLOYEE_STATUS.Leaving.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 }
             );
         }

--- a/LapStopApiSolution/Infrastructures/Entities/Configurations/InvoiceStatusConfig.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Configurations/InvoiceStatusConfig.cs
@@ -17,8 +17,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.INVOICE_STATUS.Processing.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new InvoiceStatus()
                 {
@@ -26,8 +26,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.INVOICE_STATUS.Completed.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new InvoiceStatus()
                 {
@@ -35,8 +35,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.INVOICE_STATUS.Blocked.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 }
             );
         }

--- a/LapStopApiSolution/Infrastructures/Entities/Configurations/ProductStatusConfig.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Configurations/ProductStatusConfig.cs
@@ -17,8 +17,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.PRODUCT_STATUS.InStock.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new ProductStatus()
                 {
@@ -26,8 +26,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.PRODUCT_STATUS.OutOfStock.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new ProductStatus()
                 {
@@ -35,8 +35,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.PRODUCT_STATUS.SoldOut.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 }
             );
         }

--- a/LapStopApiSolution/Infrastructures/Entities/Configurations/SalesOrderStatusConfig.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Configurations/SalesOrderStatusConfig.cs
@@ -17,8 +17,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.SALES_ORDER_STATUS.Waiting.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new SalesOrderStatus()
                 {
@@ -26,8 +26,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.SALES_ORDER_STATUS.Processing.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new SalesOrderStatus()
                 {
@@ -35,8 +35,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.SALES_ORDER_STATUS.Completed.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 },
                 new SalesOrderStatus()
                 {
@@ -44,8 +44,8 @@ namespace Entities.Configurations
                     Name = ConstSeedingData.SALES_ORDER_STATUS.Blocked.Name,
                     IsEnable = true,
                     IsRemoved = false,
-                    CreatedDate = DateTime.Now,
-                    UpdatedDate = DateTime.Now,
+                    CreatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
+                    UpdatedDate = new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local),
                 }
             );
         }

--- a/LapStopApiSolution/Infrastructures/Entities/Context/LapStopContext.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Context/LapStopContext.cs
@@ -26,7 +26,7 @@ namespace Entities.Context
 
             modelBuilder.ApplyRelationshipConfigExt();
 
-            //modelBuilder.ApplySeedingDataExt();
+            modelBuilder.ApplySeedingDataExt();
 
             base.OnModelCreating(modelBuilder);
         }

--- a/LapStopApiSolution/Infrastructures/Entities/Migrations/20230426032519_SeedingData.Designer.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Migrations/20230426032519_SeedingData.Designer.cs
@@ -4,6 +4,7 @@ using Entities.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Entities.Migrations
 {
     [DbContext(typeof(LapStopContext))]
-    partial class LapStopContextModelSnapshot : ModelSnapshot
+    [Migration("20230426032519_SeedingData")]
+    partial class SeedingData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LapStopApiSolution/Infrastructures/Entities/Migrations/20230426032519_SeedingData.cs
+++ b/LapStopApiSolution/Infrastructures/Entities/Migrations/20230426032519_SeedingData.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Entities.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedingData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "EmployeeRoles",
+                columns: new[] { "Id", "CreatedDate", "IsEnable", "IsRemoved", "Name", "UpdatedDate" },
+                values: new object[,]
+                {
+                    { new Guid("e6d15a40-d1e1-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), true, false, "Admin", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("e6d15a41-d1e1-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), true, false, "Manager", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("e6d15a42-d1e1-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), true, false, "Staff", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) }
+                });
+
+            migrationBuilder.InsertData(
+                table: "EmployeeStatuses",
+                columns: new[] { "Id", "CreatedDate", "IsEnable", "IsRemoved", "Name", "UpdatedDate" },
+                values: new object[,]
+                {
+                    { new Guid("b3d637e0-d20a-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), true, false, "On", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("b3d637e1-d20a-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), true, false, "Off", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("b3d637e2-d20a-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), true, false, "Leaving", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) }
+                });
+
+            migrationBuilder.InsertData(
+                table: "InvoiceStatus",
+                columns: new[] { "Id", "CreatedDate", "Description", "IsEnable", "IsRemoved", "Name", "UpdatedDate" },
+                values: new object[,]
+                {
+                    { new Guid("7187a500-d213-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Processing", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("7187a501-d213-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Completed", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("7187a502-d213-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Blocked", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) }
+                });
+
+            migrationBuilder.InsertData(
+                table: "ProductStatus",
+                columns: new[] { "Id", "CreatedDate", "Description", "IsEnable", "IsRemoved", "Name", "UpdatedDate" },
+                values: new object[,]
+                {
+                    { new Guid("b7ee5e90-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "In Stock", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("b7ee5e91-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Out Of Stock", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("b7ee5e92-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Sold Out", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) }
+                });
+
+            migrationBuilder.InsertData(
+                table: "SalesOrderStatus",
+                columns: new[] { "Id", "CreatedDate", "Description", "IsEnable", "IsRemoved", "Name", "UpdatedDate" },
+                values: new object[,]
+                {
+                    { new Guid("feb2d310-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Waiting", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("feb2d311-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Processing", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("feb2d312-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Completed", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) },
+                    { new Guid("feb2d313-d212-11ed-92cb-1903471dbe5a"), new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local), null, true, false, "Blocked", new DateTime(2023, 10, 27, 0, 0, 0, 0, DateTimeKind.Local) }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "EmployeeRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("e6d15a40-d1e1-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "EmployeeRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("e6d15a41-d1e1-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "EmployeeRoles",
+                keyColumn: "Id",
+                keyValue: new Guid("e6d15a42-d1e1-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "EmployeeStatuses",
+                keyColumn: "Id",
+                keyValue: new Guid("b3d637e0-d20a-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "EmployeeStatuses",
+                keyColumn: "Id",
+                keyValue: new Guid("b3d637e1-d20a-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "EmployeeStatuses",
+                keyColumn: "Id",
+                keyValue: new Guid("b3d637e2-d20a-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "InvoiceStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("7187a500-d213-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "InvoiceStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("7187a501-d213-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "InvoiceStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("7187a502-d213-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "ProductStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("b7ee5e90-d212-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "ProductStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("b7ee5e91-d212-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "ProductStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("b7ee5e92-d212-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "SalesOrderStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("feb2d310-d212-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "SalesOrderStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("feb2d311-d212-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "SalesOrderStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("feb2d312-d212-11ed-92cb-1903471dbe5a"));
+
+            migrationBuilder.DeleteData(
+                table: "SalesOrderStatus",
+                keyColumn: "Id",
+                keyValue: new Guid("feb2d313-d212-11ed-92cb-1903471dbe5a"));
+        }
+    }
+}


### PR DESCRIPTION
- Using "DateTime.Now" will create new Migration EVERYTIME we run, so we MUST use a specific value for it
=> Because the OnModelCreating() will be called when initializing Context instance ==> It also calls to Seeding func() and apply the NEW value from "DateTime.Now"