### PR TITLE
[Feature][Caching] apply ExpirationCaching by using ResponseCache library

### DIFF
--- a/LapStopApiSolution/MainAPIs/RestfulApiHandler/Controllers/BrandController.cs
+++ b/LapStopApiSolution/MainAPIs/RestfulApiHandler/Controllers/BrandController.cs
@@ -44,6 +44,7 @@ namespace RestfulApiHandler.Controllers
 
         [HttpGet]
         [Route("brands", Name = "GetAllBrands")]
+        [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any)]        
         public async Task<IActionResult> GetAllBrands([FromQuery] BrandParameters parameters)
         {
             PagedList<ShapedModel> pagedResult = await _serviceManager.Brand.GetAllAsync(parameters);

--- a/LapStopApiSolution/MainHosts/LapStopApiHost/Program.cs
+++ b/LapStopApiSolution/MainHosts/LapStopApiHost/Program.cs
@@ -10,6 +10,7 @@ using FluentValidation;
 using LapStopApiHost.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using NLog;
 using NLogLib;
 using Repositories;
@@ -44,11 +45,11 @@ builder.Services.AddControllers(config =>
         // the server doesn’t support
         config.ReturnHttpNotAcceptable = true; // 406 Not Acceptable
     })
-    .AddXmlDataContractSerializerFormatters() // support XML formatters
-    .AddMvcOptions(
-            // support CSV (custom formatter)
-            config => config.OutputFormatters.Add(new CsvOutputFormatter())
-    )
+    //.AddXmlDataContractSerializerFormatters() // support XML formatters
+    //.AddMvcOptions(
+    //        // support CSV (custom formatter)
+    //        config => config.OutputFormatters.Add(new CsvOutputFormatter())
+    //)
     .AddApplicationPart(typeof(RestfulApiHandler.AssemblyReference).Assembly)
     .AddNewtonsoftJson();
 
@@ -71,6 +72,7 @@ builder.Services.AddScoped<IDataShaper<ProductDto>, DataShaper<ProductDto>>();
 // Register ActionFilter to Services
 builder.Services.AddScoped<ValidationFilterAttribute>();
 
+builder.Services.AddResponseCaching();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -93,6 +95,11 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+// UseCors must be called before UseResponseCaching
+//app.UseCors();
+
+app.UseResponseCaching();
 
 app.UseAuthorization();
 


### PR DESCRIPTION
### `ExpirationCaching` by using `ResponseCache`:
 + ResponseCache `attribute` JUST helps to `config Control-Cache header` `(NO cache-store)`.
 + `CacheProfile` is a way to define `a BASE cache configuration`.
 + ResponseCache `middleware support Cache-Store` by adding the `"AGE"` field in Header from the `SECOND request`.
### `ValidationCache` was `NOT` supported `WELL` by `ResponseCache`