### PR TITLE
[Feature][Validation] ResponseCaching - Validation [SAME URL] - Using the Marvin package

### DIFF
--- a/LapStopApiSolution/Cores/Shared/CustomModels/DynamicObjects/ShapedModel.cs
+++ b/LapStopApiSolution/Cores/Shared/CustomModels/DynamicObjects/ShapedModel.cs
@@ -1,13 +1,7 @@
-﻿using Domains.LinkModels;
-using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.Dynamic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Schema;
 using System.Xml;
+using System.Xml.Schema;
 using System.Xml.Serialization;
 
 namespace Shared.CustomModels.DynamicObjects

--- a/LapStopApiSolution/MainAPIs/RestfulApiHandler/RestfulApiHandler.csproj
+++ b/LapStopApiSolution/MainAPIs/RestfulApiHandler/RestfulApiHandler.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Marvin.Cache.Headers" Version="6.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="7.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />


### PR DESCRIPTION
### 1) Using the `Marvin.Cache.Header` package to execute `VALIDATION`.
### 2) This package is `OPPOSING` the ResponseCachingMiddle:
### 3) `"MustRevalidate -  TRUE"` will prevent the ResponseCaching from getting data from the Cache to return.
### 4) `ExpirationOptions` were defined just as `decoration` for Reponse's Header `(NOT checking Expiration)`
### 5) Need to `mark the Invalidation` for the `out-of-date Cache`.
 