### PR TITLE
[Enhancement] Remove DbContext from RepositoryClasses

### DIFF
--- a/LapStopApiSolution/Cores/Contracts.IRepositories/Base/IAbstractEntityRepository.cs
+++ b/LapStopApiSolution/Cores/Contracts.IRepositories/Base/IAbstractEntityRepository.cs
@@ -1,20 +1,23 @@
-﻿using Contracts.IRepositories.Managers;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 
 namespace Contracts.IRepositories.Base
 {
-    public interface IAbstractEntityRepository<TModel> where TModel : class
+    public interface IAbstractEntityRepository<TEntity> : IAbstractRepository where TEntity : class
     {
-        IQueryable<TModel> FindAll(bool isTrackChanges);
+        IQueryable<TEntity> FindAll(bool isTrackChanges);
 
-        IQueryable<TModel> FindByCondition(bool isTrackChanges, Expression<Func<TModel, bool>> expression);
+        IQueryable<TEntity> FindByCondition(bool isTrackChanges, Expression<Func<TEntity, bool>> expression);
 
-        void CreateEntity(TModel obj);
+        void CreateEntity(TEntity obj);
 
-        void UpdateEntity(TModel obj);
+        void UpdateEntity(TEntity obj);
 
-        void DeleteEntity(TModel obj);
+        void DeleteEntity(TEntity obj);
 
-        void DeleteEntityPermanently(TModel obj);
+        void DeleteEntityPermanently(TEntity obj);
+
+        Task BulkCreateEntities(IEnumerable<TEntity> entities);
+
+        Task BulkUpdateEntities(IEnumerable<TEntity> entities);
     }
 }

--- a/LapStopApiSolution/Logic/Repositories/DomainRepositories.cs
+++ b/LapStopApiSolution/Logic/Repositories/DomainRepositories.cs
@@ -19,7 +19,7 @@ namespace Repositories
             _context = context;
 
             _entityRepositories = new Lazy<IEntityRepositoryManager>(() 
-                    => new EntityRepositoryManager(context, this));
+                    => new EntityRepositoryManager(new EntityRepositoryParams(context, this)));
 
             _identityRepositories = new Lazy<IIdentityRepositoryManager>(() 
                     => new IdentityRepositoryManager(this, userManager, roleManager));
@@ -33,7 +33,5 @@ namespace Repositories
         public IEntityRepositoryManager EntityRepositories => _entityRepositories.Value;
 
         public IIdentityRepositoryManager IdentityRepositories => _identityRepositories.Value;
-
-        public LapStopContext DomainContext => _context;
     }
 }

--- a/LapStopApiSolution/Logic/Repositories/Entities/BrandRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/BrandRepository.cs
@@ -2,9 +2,7 @@
 {
     internal sealed class BrandRepository : AbstractEntityRepository<Brand>, IBrandRepository
     {
-        public BrandRepository(LapStopContext context, 
-                                IDomainRepositories domainRepositories) 
-            : base(context, domainRepositories)
+        public BrandRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/CartItemRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/CartItemRepository.cs
@@ -2,9 +2,7 @@
 {
     internal sealed class CartItemRepository : AbstractEntityRepository<CartItem>, ICartItemRepository
     {
-        public CartItemRepository(LapStopContext context,
-                                IDomainRepositories domainRepositories)
-            : base(context, domainRepositories)
+        public CartItemRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/CartRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/CartRepository.cs
@@ -2,9 +2,7 @@
 {
     internal sealed class CartRepository : AbstractEntityRepository<Cart>, ICartRepository
     {
-        public CartRepository(LapStopContext context,
-                                IDomainRepositories domainRepositories)
-            : base(context, domainRepositories)
+        public CartRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/CustomerAccountRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/CustomerAccountRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class CustomerAccountRepository : AbstractEntityRepository<CustomerAccount>, ICustomerAccountRepository
     {
-        public CustomerAccountRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public CustomerAccountRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/CustomerRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/CustomerRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class CustomerRepository : AbstractEntityRepository<Customer>, ICustomerRepository
     {
-        public CustomerRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public CustomerRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/EmployeeAccountRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/EmployeeAccountRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class EmployeeAccountRepository : AbstractEntityRepository<EmployeeAccount>, IEmployeeAccountRepository
     {
-        public EmployeeAccountRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public EmployeeAccountRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/EmployeeGalleryRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/EmployeeGalleryRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class EmployeeGalleryRepository : AbstractEntityRepository<EmployeeGallery>, IEmployeeGalleryRepository
     {
-        public EmployeeGalleryRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public EmployeeGalleryRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/EmployeeRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/EmployeeRepository.cs
@@ -4,7 +4,7 @@ namespace Repositories.Entities
 {
     internal sealed class EmployeeRepository : AbstractEntityRepository<Employee>, IEmployeeRepository
     {
-        public EmployeeRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public EmployeeRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/EmployeeRoleRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/EmployeeRoleRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class EmployeeRoleRepository : AbstractEntityRepository<EmployeeRole>, IEmployeeRoleRepository
     {
-        public EmployeeRoleRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public EmployeeRoleRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/EmployeeStatusRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/EmployeeStatusRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class EmployeeStatusRepository : AbstractEntityRepository<EmployeeStatus>, IEmployeeStatusRepository
     {
-        public EmployeeStatusRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public EmployeeStatusRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/ExportedInvoiceDetailRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ExportedInvoiceDetailRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ExportedInvoiceDetailRepository : AbstractEntityRepository<ExportedInvoiceDetail>, IExportedInvoiceDetailRepository
     {
-        public ExportedInvoiceDetailRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ExportedInvoiceDetailRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/ExportedInvoiceRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ExportedInvoiceRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ExportedInvoiceRepository : AbstractEntityRepository<ExportedInvoice>, IExportedInvoiceRepository
     {
-        public ExportedInvoiceRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ExportedInvoiceRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/ImportedInvoiceDetailRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ImportedInvoiceDetailRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ImportedInvoiceDetailRepository : AbstractEntityRepository<ImportedInvoiceDetail>, IImportedInvoiceDetailRepository
     {
-        public ImportedInvoiceDetailRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ImportedInvoiceDetailRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/ImportedInvoiceRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ImportedInvoiceRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ImportedInvoiceRepository : AbstractEntityRepository<ImportedInvoice>, IImportedInvoiceRepository
     {
-        public ImportedInvoiceRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ImportedInvoiceRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/InvoiceStatusRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/InvoiceStatusRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class InvoiceStatusRepository : AbstractEntityRepository<InvoiceStatus>, IInvoiceStatusRepository
     {
-        public InvoiceStatusRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public InvoiceStatusRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/ProductBrandRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ProductBrandRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ProductBrandRepository : AbstractEntityRepository<ProductBrand>, IProductBrandRepository
     {
-        public ProductBrandRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ProductBrandRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/ProductGalleryRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ProductGalleryRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ProductGalleryRepository : AbstractEntityRepository<ProductGallery>, IProductGalleryRepository
     {
-        public ProductGalleryRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ProductGalleryRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/ProductRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ProductRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ProductRepository : AbstractEntityRepository<Product>, IProductRepository
     {
-        public ProductRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ProductRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 
@@ -44,16 +44,13 @@
 
         public async Task BulkCreateAsync(IEnumerable<Product> products)
         {
-            await _context.BulkInsertAsync(products, options =>
-            {
-                options.InsertIfNotExists = true;
-            });
+            await base.BulkCreateEntities(products);
         }
 
         public async Task BulkUpdateAsync(IEnumerable<Product> products)
         {
             // if having Tracking, can use BulkSaveChangesAsync() 
-            await _context.BulkUpdateAsync(products);
+            await base.BulkUpdateEntities(products);
         }
 
         public async Task BulkDeleteAsync(IEnumerable<Product> products)
@@ -62,7 +59,7 @@
             {
                 product.IsRemoved = true;
             }
-            await _context.BulkUpdateAsync(products);
+            await base.BulkUpdateEntities(products);
         }
 
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/ProductStatusRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/ProductStatusRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class ProductStatusRepository : AbstractEntityRepository<ProductStatus>, IProductStatusRepository
     {
-        public ProductStatusRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public ProductStatusRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Entities/SalesOrderDetailRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/SalesOrderDetailRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class SalesOrderDetailRepository : AbstractEntityRepository<SalesOrderDetail>, ISalesOrderDetailRepository
     {
-        public SalesOrderDetailRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public SalesOrderDetailRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/SalesOrderRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/SalesOrderRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class SalesOrderRepository : AbstractEntityRepository<SalesOrder>, ISalesOrderRepository
     {
-        public SalesOrderRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public SalesOrderRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
     }

--- a/LapStopApiSolution/Logic/Repositories/Entities/SalesOrderStatusRepository.cs
+++ b/LapStopApiSolution/Logic/Repositories/Entities/SalesOrderStatusRepository.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class SalesOrderStatusRepository : AbstractEntityRepository<SalesOrderStatus>, ISalesOrderStatusRepository
     {
-        public SalesOrderStatusRepository(LapStopContext context, IDomainRepositories domainRepositories) : base(context, domainRepositories)
+        public SalesOrderStatusRepository(EntityRepositoryParams repoParams) : base(repoParams)
         {
         }
 

--- a/LapStopApiSolution/Logic/Repositories/Managers/EntityRepositoryManager.cs
+++ b/LapStopApiSolution/Logic/Repositories/Managers/EntityRepositoryManager.cs
@@ -28,30 +28,30 @@ namespace Repositories.Managers
         private readonly Lazy<ISalesOrderDetailRepository> _salesOrderDetailRepository;
         private readonly Lazy<ISalesOrderStatusRepository> _salesOrderStatusRepository;
 
-        public EntityRepositoryManager(LapStopContext context, IDomainRepositories domainRepositories)
+        public EntityRepositoryManager(EntityRepositoryParams repoParams)
         {
-            _brandRepository = new Lazy<IBrandRepository>(() => new BrandRepository(context, domainRepositories));
-            _cartRepository = new Lazy<ICartRepository>(() => new CartRepository(context, domainRepositories));
-            _cartItemRepository = new Lazy<ICartItemRepository>(() => new CartItemRepository(context, domainRepositories));
-            _customerAccountRepository = new Lazy<ICustomerAccountRepository>(() => new CustomerAccountRepository(context, domainRepositories));
-            _customerRepository = new Lazy<ICustomerRepository>(() => new CustomerRepository(context, domainRepositories));
-            _employeeAccountRepository = new Lazy<IEmployeeAccountRepository>(() => new EmployeeAccountRepository(context, domainRepositories));
-            _employeeGalleryRepository = new Lazy<IEmployeeGalleryRepository>(() => new EmployeeGalleryRepository(context, domainRepositories));
-            _employeeRepository = new Lazy<IEmployeeRepository>(() => new EmployeeRepository(context, domainRepositories));
-            _employeeRoleRepository = new Lazy<IEmployeeRoleRepository>(() => new EmployeeRoleRepository(context, domainRepositories));
-            _employeeStatusRepository = new Lazy<IEmployeeStatusRepository>(() => new EmployeeStatusRepository(context, domainRepositories));
-            _exportedInvoiceRepository = new Lazy<IExportedInvoiceRepository>(() => new ExportedInvoiceRepository(context, domainRepositories));
-            _exportedInvoiceDetailRepository = new Lazy<IExportedInvoiceDetailRepository>(() => new ExportedInvoiceDetailRepository(context, domainRepositories));
-            _importedInvoiceRepository = new Lazy<IImportedInvoiceRepository>(() => new ImportedInvoiceRepository(context, domainRepositories));
-            _importedInvoiceDetailRepository = new Lazy<IImportedInvoiceDetailRepository>(() => new ImportedInvoiceDetailRepository(context, domainRepositories));
-            _invoiceStatusRepository = new Lazy<IInvoiceStatusRepository>(() => new InvoiceStatusRepository(context, domainRepositories));
-            _productBrandRepository = new Lazy<IProductBrandRepository>(() => new ProductBrandRepository(context, domainRepositories));
-            _productGalleryRepository = new Lazy<IProductGalleryRepository>(() => new ProductGalleryRepository(context, domainRepositories));
-            _productRepository = new Lazy<IProductRepository>(() => new ProductRepository(context, domainRepositories));
-            _productStatusRepository = new Lazy<IProductStatusRepository>(() => new ProductStatusRepository(context, domainRepositories));
-            _salesOrderRepository = new Lazy<ISalesOrderRepository>(() => new SalesOrderRepository(context, domainRepositories));
-            _salesOrderDetailRepository = new Lazy<ISalesOrderDetailRepository>(() => new SalesOrderDetailRepository(context, domainRepositories));
-            _salesOrderStatusRepository = new Lazy<ISalesOrderStatusRepository>(() => new SalesOrderStatusRepository(context, domainRepositories));
+            _brandRepository = new Lazy<IBrandRepository>(() => new BrandRepository(repoParams));
+            _cartRepository = new Lazy<ICartRepository>(() => new CartRepository(repoParams));
+            _cartItemRepository = new Lazy<ICartItemRepository>(() => new CartItemRepository(repoParams));
+            _customerAccountRepository = new Lazy<ICustomerAccountRepository>(() => new CustomerAccountRepository(repoParams));
+            _customerRepository = new Lazy<ICustomerRepository>(() => new CustomerRepository(repoParams));
+            _employeeAccountRepository = new Lazy<IEmployeeAccountRepository>(() => new EmployeeAccountRepository(repoParams));
+            _employeeGalleryRepository = new Lazy<IEmployeeGalleryRepository>(() => new EmployeeGalleryRepository(repoParams));
+            _employeeRepository = new Lazy<IEmployeeRepository>(() => new EmployeeRepository(repoParams));
+            _employeeRoleRepository = new Lazy<IEmployeeRoleRepository>(() => new EmployeeRoleRepository(repoParams));
+            _employeeStatusRepository = new Lazy<IEmployeeStatusRepository>(() => new EmployeeStatusRepository(repoParams));
+            _exportedInvoiceRepository = new Lazy<IExportedInvoiceRepository>(() => new ExportedInvoiceRepository(repoParams));
+            _exportedInvoiceDetailRepository = new Lazy<IExportedInvoiceDetailRepository>(() => new ExportedInvoiceDetailRepository(repoParams));
+            _importedInvoiceRepository = new Lazy<IImportedInvoiceRepository>(() => new ImportedInvoiceRepository(repoParams));
+            _importedInvoiceDetailRepository = new Lazy<IImportedInvoiceDetailRepository>(() => new ImportedInvoiceDetailRepository(repoParams));
+            _invoiceStatusRepository = new Lazy<IInvoiceStatusRepository>(() => new InvoiceStatusRepository(repoParams));
+            _productBrandRepository = new Lazy<IProductBrandRepository>(() => new ProductBrandRepository(repoParams));
+            _productGalleryRepository = new Lazy<IProductGalleryRepository>(() => new ProductGalleryRepository(repoParams));
+            _productRepository = new Lazy<IProductRepository>(() => new ProductRepository(repoParams));
+            _productStatusRepository = new Lazy<IProductStatusRepository>(() => new ProductStatusRepository(repoParams));
+            _salesOrderRepository = new Lazy<ISalesOrderRepository>(() => new SalesOrderRepository(repoParams));
+            _salesOrderDetailRepository = new Lazy<ISalesOrderDetailRepository>(() => new SalesOrderDetailRepository(repoParams));
+            _salesOrderStatusRepository = new Lazy<ISalesOrderStatusRepository>(() => new SalesOrderStatusRepository(repoParams));
         }
 
         public IBrandRepository Brand => _brandRepository.Value;

--- a/LapStopApiSolution/Logic/Repositories/Parameters/EntityRepositoryParams.cs
+++ b/LapStopApiSolution/Logic/Repositories/Parameters/EntityRepositoryParams.cs
@@ -1,0 +1,15 @@
+﻿namespace Repositories.Parameters
+{
+    internal sealed class EntityRepositoryParams
+    {
+        public readonly LapStopContext Context;
+        public readonly IDomainRepositories DomainRepositories;
+
+        public EntityRepositoryParams(LapStopContext context, IDomainRepositories domainRepositories)
+        {
+            Context = context;
+            DomainRepositories = domainRepositories;
+        }
+
+    }
+}

--- a/LapStopApiSolution/Logic/Repositories/Using.cs
+++ b/LapStopApiSolution/Logic/Repositories/Using.cs
@@ -8,3 +8,4 @@ global using EFCoreService.Context;
 global using Microsoft.EntityFrameworkCore;
 global using Repositories.Base;
 global using System.Linq.Dynamic.Core;
+global using Repositories.Parameters;


### PR DESCRIPTION
### By using `EntityRepositoryParams` class to transmit params. 
### It helps remove the `dependency` `DbContext` in `AbstractRepository`. 
### If there are any changes, just modify them in one place - inside `EntityRepositoryParams` class