### PR TITLE
[Enhancement] apply ApiResponse flow

### DIFF
--- a/LapStopApiSolution/Cores/Common/Models/Responses/ErrorResponseModel.cs
+++ b/LapStopApiSolution/Cores/Common/Models/Responses/ErrorResponseModel.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
 
-namespace Common.Models.Errors
+namespace Common.Models.Responses
 {
     public sealed class ErrorResponseModel
     {

--- a/LapStopApiSolution/Cores/Contracts.IServices/Entities/IEmployeeService.cs
+++ b/LapStopApiSolution/Cores/Contracts.IServices/Entities/IEmployeeService.cs
@@ -1,8 +1,10 @@
-﻿namespace Contracts.IServices.Entities
+﻿using DTO.Output.ApiResponses.Bases;
+
+namespace Contracts.IServices.Entities
 {
     public interface IEmployeeService
     {
-        Task<PagedList<ExpandoForXmlObject>> GetAllAsync(EmployeeRequestParam parameter);
+        Task<ApiResponseBase> GetAllAsync(EmployeeRequestParam parameter);
 
         Task<EmployeeDto?> GetOneByIdAsync(Guid employeeId);
 

--- a/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiBadRequestResponse.cs
+++ b/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiBadRequestResponse.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace DTO.Output.ApiResponses.Bases
+{
+    public abstract class ApiBadRequestResponse : ApiResponseBase
+    {
+        public ApiBadRequestResponse(string message)
+            : base(isSuccess: false)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+    }
+}

--- a/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiNotFoundResponse.cs
+++ b/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiNotFoundResponse.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace DTO.Output.ApiResponses.Bases
+{
+    public abstract class ApiNotFoundResponse : ApiResponseBase
+    {
+        public ApiNotFoundResponse(string message)
+            : base(isSuccess: false)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+    }
+}

--- a/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiOkResponse.cs
+++ b/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiOkResponse.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace DTO.Output.ApiResponses.Bases
+{
+    public sealed class ApiOkResponse<TReturnedDataType> : ApiResponseBase
+    {
+        public ApiOkResponse(TReturnedDataType data)
+            : base(isSuccess: true)
+        {
+            Data = data;
+        }
+
+        public TReturnedDataType Data { get; }
+    }
+}

--- a/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiResponseBase.cs
+++ b/LapStopApiSolution/Cores/DTO/Output/ApiResponses/Bases/ApiResponseBase.cs
@@ -1,0 +1,12 @@
+﻿namespace DTO.Output.ApiResponses.Bases
+{
+    public abstract class ApiResponseBase
+    {
+        protected ApiResponseBase(bool isSuccess)
+        {
+            IsSuccess = isSuccess;
+        }
+
+        public bool IsSuccess { get; }
+    }
+}

--- a/LapStopApiSolution/Cores/DTO/Output/ApiResponses/ErrorBadRequest/EmployeeInvaidAgeRangeBadRequestResponse.cs
+++ b/LapStopApiSolution/Cores/DTO/Output/ApiResponses/ErrorBadRequest/EmployeeInvaidAgeRangeBadRequestResponse.cs
@@ -1,0 +1,13 @@
+﻿using Common.Functions;
+using DTO.Output.ApiResponses.Bases;
+
+namespace DTO.Output.ApiResponses.ErrorBadRequest
+{
+    public sealed class EmployeeInvaidAgeRangeBadRequestResponse : ApiBadRequestResponse
+    {
+        public EmployeeInvaidAgeRangeBadRequestResponse()
+            : base(CommonFunctions.DisplayErrors.ReturnInvalidAgeRangeMessage)
+        {
+        }
+    }
+}

--- a/LapStopApiSolution/Cores/DTO/Output/ApiResponses/ErrorNotFound/EmployeeNotFoundReponse.cs
+++ b/LapStopApiSolution/Cores/DTO/Output/ApiResponses/ErrorNotFound/EmployeeNotFoundReponse.cs
@@ -1,0 +1,12 @@
+﻿using DTO.Output.ApiResponses.Bases;
+
+namespace DTO.Output.ApiResponses.ErrorNotFound
+{
+    public sealed class EmployeeNotFoundReponse : ApiNotFoundResponse
+    {
+        public EmployeeNotFoundReponse(Guid id)
+            : base($"Employee with id: {id} is not found in DB")
+        {
+        }
+    }
+}

--- a/LapStopApiSolution/MainAPIs/RestfulApiHandler/Base/AbstractApiVer01Controller.cs
+++ b/LapStopApiSolution/MainAPIs/RestfulApiHandler/Base/AbstractApiVer01Controller.cs
@@ -1,4 +1,7 @@
-﻿using Contracts.IServices.Managers;
+﻿using Common.Models.Responses;
+using Contracts.IServices.Managers;
+using DTO.Output.ApiResponses.Bases;
+using Microsoft.AspNetCore.Http;
 
 namespace RestfulApiHandler.Base
 {
@@ -22,6 +25,25 @@ namespace RestfulApiHandler.Base
         public virtual IIdentityServiceManager IdentityServices => _domainServices.IdentityServices;
 
         public virtual ILogService LogService => _logService;
+
+        [NonAction]
+        public IActionResult ProcessErrorResponse(ApiResponseBase apiResponse)
+        {
+            return apiResponse switch
+            {
+                ApiNotFoundResponse => NotFound(new ErrorResponseModel()
+                {
+                    StatusCode = StatusCodes.Status404NotFound,
+                    Message = ((ApiNotFoundResponse)apiResponse).Message
+                }),
+                ApiBadRequestResponse => BadRequest(new ErrorResponseModel()
+                {
+                    StatusCode = StatusCodes.Status400BadRequest,
+                    Message = ((ApiBadRequestResponse)apiResponse).Message
+                }),
+                _ => throw new NotImplementedException()
+            };
+        }
 
     }
 }

--- a/LapStopApiSolution/MainAPIs/RestfulApiHandler/Controllers/Entities/EmployeeController.cs
+++ b/LapStopApiSolution/MainAPIs/RestfulApiHandler/Controllers/Entities/EmployeeController.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using DTO.Output.ApiResponses.Bases;
+using RestfulApiHandler.Extensions;
 
 namespace RestfulApiHandler.Controllers.Entities
 {
     public sealed class EmployeeController : AbstractApiVer01Controller
     {
         public EmployeeController(ILogService logService,
-                                IDomainServices domainServices)
+                                  IDomainServices domainServices)
             : base(logService, domainServices)
         {
         }
@@ -14,33 +15,29 @@ namespace RestfulApiHandler.Controllers.Entities
         [Route("employees", Name = "GetAllEmployeesHead")]
         public async Task<IActionResult> GetAllEmployeesHead([FromQuery] EmployeeRequestParam parameter)
         {
-            if (parameter.MinAge > parameter.MaxAge)
+            ApiResponseBase apiResponse = await EntityServices.Employee.GetAllAsync(parameter);
+            if (apiResponse.IsSuccess)
             {
-                return BadRequest(CommonFunctions.DisplayErrors.ReturnInvalidAgeRangeMessage);
+                var metaData = apiResponse.GetResult<PagedList<ExpandoForXmlObject>>().MetaData;
+                Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metaData));
+                return Ok(apiResponse);
             }
-
-            PagedList<ExpandoForXmlObject> pagedResult = await EntityServices.Employee.GetAllAsync(parameter);
-
-            Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(pagedResult.MetaData));
-
-            return Ok();
+            return ProcessErrorResponse(apiResponse);
         }
 
-        [Authorize]
+        //[Authorize]
         [HttpGet]
         [Route("employees", Name = "GetAllEmployees")]
         public async Task<IActionResult> GetAllEmployees([FromQuery] EmployeeRequestParam parameter)
         {
-            if (parameter.MinAge > parameter.MaxAge)
+            ApiResponseBase apiResponse = await EntityServices.Employee.GetAllAsync(parameter);
+            if (apiResponse.IsSuccess)
             {
-                return BadRequest(CommonFunctions.DisplayErrors.ReturnInvalidAgeRangeMessage);
+                var metaData = apiResponse.GetResult<PagedList<ExpandoForXmlObject>>().MetaData;
+                Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(metaData));
+                return Ok(apiResponse);
             }
-
-            PagedList<ExpandoForXmlObject> pagedResult = await EntityServices.Employee.GetAllAsync(parameter);
-
-            Response.Headers.Add("X-Pagination", JsonSerializer.Serialize(pagedResult.MetaData));
-
-            return Ok(pagedResult);
+            return ProcessErrorResponse(apiResponse);
         }
 
         [HttpGet]

--- a/LapStopApiSolution/MainAPIs/RestfulApiHandler/Extensions/ApiBaseResponseExtensions.cs
+++ b/LapStopApiSolution/MainAPIs/RestfulApiHandler/Extensions/ApiBaseResponseExtensions.cs
@@ -1,0 +1,12 @@
+﻿using DTO.Output.ApiResponses.Bases;
+
+namespace RestfulApiHandler.Extensions
+{
+    public static class ApiBaseResponseExtensions
+    {
+        public static TResultType GetResult<TResultType>(this ApiResponseBase apiResponse)
+        {
+            return ((ApiOkResponse<TResultType>)apiResponse).Data;
+        }
+    }
+}

--- a/LapStopApiSolution/MainHosts/LapStopApiHost/.config/dotnet-tools.json
+++ b/LapStopApiSolution/MainHosts/LapStopApiHost/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "7.0.8",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/LapStopApiSolution/MainHosts/LapStopApiHost/Extensions/ExceptionMiddlewareExtensions.cs
+++ b/LapStopApiSolution/MainHosts/LapStopApiHost/Extensions/ExceptionMiddlewareExtensions.cs
@@ -1,6 +1,5 @@
-﻿using Common.Models.Errors;
-using Common.Models.Exceptions;
-using Contracts.Utilities.Logger;
+﻿using Common.Models.Exceptions;
+using Common.Models.Responses;
 using Microsoft.AspNetCore.Diagnostics;
 
 namespace LapStopApiHost.Extensions


### PR DESCRIPTION
### We use `ApiResponseBase` as a Response class for `Controllers` - both Success and Failed results (`instead of` returning the `concrete types`).